### PR TITLE
Fix broken links

### DIFF
--- a/2016-11-21-tidb-weekly.md
+++ b/2016-11-21-tidb-weekly.md
@@ -65,4 +65,4 @@ Last week, we landed [19 PRs](https://github.com/search?utf8=%E2%9C%93&q=repo%3A
 
 + [Abstract a Selector](https://github.com/pingcap/pd/pull/388) to handle different strategies to select stores. 
 
-+ Enlarge the [latches size]([https://github.com/pingcap/tikv/pull/1321](https://github.com/pingcap/tikv/pull/1321)) of the scheduler to reduce lock conflicts.
++ Enlarge the [latches size](https://github.com/pingcap/tikv/pull/1321) of the scheduler to reduce lock conflicts.

--- a/2016-11-28-tidb-weekly.md
+++ b/2016-11-28-tidb-weekly.md
@@ -46,7 +46,7 @@ Last week, we landed [44 PRs](https://github.com/pingcap/tidb/pulls?utf8=✓&q=i
 Add the following new guides:
 
 * [TiDB Cluster Troubleshooting Guide](https://github.com/pingcap/docs/blob/master/trouble-shooting.md)
-* [TiKV Tuning Guide](https://github.com/pingcap/docs/blob/master/op-guide/tune-TiKV.md)
+* [TiKV Tuning Guide](https://github.com/pingcap/docs/blob/master/op-guide/tune-tikv.md)
 
 # Weekly update in TiKV
 
@@ -80,7 +80,7 @@ Last week, we landed [20 PRs](https://github.com/search?p=1&q=repo%3Apingcap%2Ft
 
 + [Abstract a Selector](https://github.com/pingcap/pd/pull/389) to schedule region peer.
 
-+ Split the [`Raft Ready` handle](https://github.com/pingcap/pd/pull/1322) to two handles: `Append` and `Apply`. 
++ Split the `Raft Ready` handle to two handles: `Append` and `Apply`. 
 
 + Use [larger Heartbeat and Election timeout](https://github.com/pingcap/pd/pull/391) to reduce the network pressure. 
 

--- a/2017-08-14-tidb-weekly.md
+++ b/2017-08-14-tidb-weekly.md
@@ -29,7 +29,7 @@ Last week, we landed [78 PRs](https://github.com/pingcap/tidb/pulls?utf8=%E2%9C%
 * Refactor the following expressions/builtin-functions evaluation framework:
   - [Plus](https://github.com/pingcap/tidb/pull/3858)
   - [Multiply](https://github.com/pingcap/tidb/pull/4118)
-  - [Minus](https://github.com/pingcap/tidb/pullt/4077)
+  - [Minus](https://github.com/pingcap/tidb/pull/4077)
   - [lpad/rpad](https://github.com/pingcap/tidb/pull/4036)
   - [bin](https://github.com/pingcap/tidb/pull/4039)
   - [from_base64](https://github.com/pingcap/tidb/pull/4040)


### PR DESCRIPTION
Remove the broken link in 2016-11-28-tidb-weekly.  Fix the broken links in the other three files. @lilin90 